### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -166,9 +166,11 @@ DKR_VOLUMES=() EXTRA_VOLUMES=()
 
 STEEM_REPLAY_ARGS=()
 
-if [[ -f .env ]]; then
-    source .env
-fi
+#Find all .env files and source the options for the docker container
+for f in *.env
+do
+    source $f
+done
 
 : ${CONFIG_FILE="${DATADIR}/witness_node_data_dir/config.ini"}
 : ${NETWORK="hive"}


### PR DESCRIPTION
The current method used within 'run.sh' was not sourcing the .env file in the hive-docker directory for me.  I am running Debian 10.

I was wondering why my container was called 'seed' even though I named it something else within my .env file.  This change fixes that and uses the .env file I have created(or any for that matter).